### PR TITLE
fix: libnuma not being found 

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,7 +36,6 @@ parts:
     override-build: |
       craftctl set version=$(oslat --version | cut -d ' ' -f 3)
     stage-packages:
-      - libnuma1
       - rt-tests
 
 apps:


### PR DESCRIPTION
- fixes #4 deb pkg problem 
- Seems that the addition of `libnuma` in stage packages causes a misleading configuration on snap build process.
- Instead, it seems better to let debian package management to figure out the needed packages.
 