### PR TITLE
feat: add missing capabilities to deadline_test

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+PR description, link to relevant issues and PRs
+
+## Testing Steps
+<!-- Steps to test the changes. Remove if not relevant -->
+
+<!-- Reminders:
+ - Incremented the snap version
+ - Added or updated tests
+ - Updated the CI/CD pipelines
+ - Updated the README(s)
+ - Updated external documentation
+-->

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,10 +49,10 @@ jobs:
 
       - name: Connectins snap interface
         run: |
-          sudo snap connect rt-tests:process-control :process-control
-          sudo snap connect rt-tests:system-trace    :system-trace
-          sudo snap connect rt-tests:mount-observe   :mount-observe
-          sudo snap connect rt-tests:sched-debugfs   :system-files
+          sudo snap connect rt-tests:process-control
+          sudo snap connect rt-tests:system-trace
+          sudo snap connect rt-tests:mount-observe
+          sudo snap connect rt-tests:scheduler-debugfs
 
       - name: Creating snap aliases
         working-directory: test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
           sudo snap connect rt-tests:mount-observe
           sudo snap connect rt-tests:system-trace
           sudo snap connect rt-tests:scheduler-debugfs
-          sudo snap connect rt-tests:cpu-latency-dev rt-tests:dma-latency-dev
+          sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
 
 
       - name: Creating snap aliases

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
           sudo snap connect rt-tests:mount-observe
           sudo snap connect rt-tests:system-trace
           sudo snap connect rt-tests:scheduler-debugfs
-          sudo snap connect rt-tests:cpu-latency-dev rt-tests:dma-latency-dev
+          #sudo snap connect rt-tests:cpu-latency-dev rt-tests:dma-latency-dev
 
       - name: Creating snap aliases
         working-directory: test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
           sudo snap connect rt-tests:mount-observe
           sudo snap connect rt-tests:system-trace
           sudo snap connect rt-tests:scheduler-debugfs
-          #sudo snap connect rt-tests:cpu-latency-dev rt-tests:dma-latency-dev
+          sudo snap connect rt-tests:cpu-latency-dev rt-tests:dma-latency-dev
 
 
       - name: Creating snap aliases

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, fix-confinement ]
   # Allow manual trigger
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,9 @@ jobs:
       - name: Connectins snap interface
         run: |
           sudo snap connect rt-tests:process-control :process-control
+          sudo snap connect rt-tests:system-trace    :system-trace
+          sudo snap connect rt-tests:mount-observe   :mount-observe
+          sudo snap connect rt-tests:sched-debugfs   :system-files
 
       - name: Creating snap aliases
         working-directory: test

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It's necessary to connect:
 - [mount-observe](https://snapcraft.io/docs/mount-observe-interface) interface;
 - [system-trace](https://snapcraft.io/docs/system-trace-interface) interface;
 - `scheduler-debugfs` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
-- The `custom-cpu-latency` plug into the `custom-cpu-latency-dev`.
+- The `custom-cpu-latency` plug into the `custom-cpu-latency-dev` slot using the [custom-device](https://snapcraft.io/docs/custom-device-interface).
 
 ```bash
 sudo snap connect rt-tests:process-control

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ sudo snap install rt-tests
 
 ## Configure
 
-It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface) interface to work properly:
-
+It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface), [mount-observe](https://snapcraft.io/docs/mount-observe-interface) and [system-trace](https://snapcraft.io/docs/system-trace-interface) interfaces to work properly:
 ```bash
 sudo snap connect rt-tests:process-control :process-control
+sudo snap connect rt-tests:mount-observe :mount-observe
+sudo snap connect rt-tests:system-trace :system-trace
 ```
 
 ## Use

--- a/README.md
+++ b/README.md
@@ -94,8 +94,14 @@ sudo snap alias rt-tests.svsematest svsematest
 
 ### Local Build
 
+Firstly, build it using [Snapcraft](https://snapcraft.io/snapcraft):
+
 ```bash
 snapcraft -v
+```
 
+Then, install it in [dangerous mode](https://snapcraft.io/docs/install-modes#heading--dangerous):
+
+```bash
 sudo snap install --dangerous *.snap
 ```

--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ sudo snap install rt-tests
 
 ## Configure
 
-It's necessary to connect the interfaces:
-- [process-control](https://snapcraft.io/docs/process-control-interface);
-- [mount-observe](https://snapcraft.io/docs/mount-observe-interface);
-- [system-trace](https://snapcraft.io/docs/system-trace-interface); 
-- connect the `custom-cpu-latency` plug into the `custom-cpu-latency-dev`:
+It's necessary to connect:
+- [process-control](https://snapcraft.io/docs/process-control-interface) interface;
+- [mount-observe](https://snapcraft.io/docs/mount-observe-interface) interface;
+- [system-trace](https://snapcraft.io/docs/system-trace-interface) interface;
+- `scheduler-debugfs` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
+- The `custom-cpu-latency` plug into the `custom-cpu-latency-dev`.
 
 ```bash
 sudo snap connect rt-tests:process-control
 sudo snap connect rt-tests:mount-observe
 sudo snap connect rt-tests:system-trace
+sudo snap connect rt-tests:scheduler-debugfs
 sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
 ```
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,10 @@ platforms:
     build-for: [arm64]
 
 plugs:
+  scheduler-debugfs:
+    interface: system-files
+    write:
+      - /sys/kernel/debug/sched/features
   process-control:
     interface: process-control
 
@@ -49,6 +53,7 @@ apps:
 
   deadline-test:
     command: usr/bin/deadline_test
+    plugs: [ mount-observe, system-trace, scheduler-debugfs ]
   
   hackbench:
     command: usr/bin/hackbench

--- a/test/rt-deadline_test
+++ b/test/rt-deadline_test
@@ -2,9 +2,6 @@
 
 . common
 
-# Skipping this because of: https://github.com/canonical/rt-tests-snap/issues/8
-skip_test
-
 test_init $(basename "$0")
 
 catch deadline_test -t $(nproc) -s 3500 -i 50
@@ -18,7 +15,6 @@ app_regex=(
 	'New calculated loops for \d+us=\d+' \
 	'Diff from last calculation: -?\d+ loops'
 	'deadline thread \d+' \
-	'thread\[\d+\] runtime=\d+us deadline=\d+ loops=\d+' \
 	'missed deadlines\s*=\s*\d+' \
 	'missed periods\s*=\s*\d+' \
 	'Total adjustments\s*=\s*\d+\s*us' \


### PR DESCRIPTION
## Summary
Add missing capabilities to deadline_test app: 
- add interface [mount-observe](https://snapcraft.io/docs/mount-observe-interface)
- add interface [system-trace](https://snapcraft.io/docs/system-trace-interface)

- Related to #8. 