### PR TITLE
fix: cyclicdeadline missing interface

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,8 @@ jobs:
       - name: Connectins snap interface
         run: |
           sudo snap connect rt-tests:process-control :process-control
+          sudo snap connect rt-tests:mount-observe :mount-observe
+          sudo snap connect rt-tests:system-trace :system-trace
 
       - name: Creating snap aliases
         working-directory: test

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ sudo snap install rt-tests
 
 ## Configure
 
-It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface) interface to work properly:
+It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface), [mount-observe](https://snapcraft.io/docs/mount-observe-interface) and [system-trace](https://snapcraft.io/docs/system-trace-interface) interfaces to work properly:
 
 ```bash
 sudo snap connect rt-tests:process-control :process-control
+sudo snap connect rt-tests:mount-observe :mount-observe
+sudo snap connect rt-tests:system-trace :system-trace
 ```
 
 ## Use

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,7 @@ apps:
 
   cyclicdeadline:
     command: usr/bin/cyclicdeadline
+    plugs: [ mount-observe, system-trace ]
   
   cyclictest:
     command: usr/bin/cyclictest


### PR DESCRIPTION
## Summary

Fixes noncritical AppArmor denials related to `cyclicdeadline`

- fixes #9
- add [system-trace interface](https://snapcraft.io/docs/system-trace-interface) and [mount-observe interface](https://snapcraft.io/docs/mount-observe-interface)

Without `mount-observe` we have the following denial logs from AppArmor:
```log
= AppArmor =
Time: Jun 24 08:47:30
Log: apparmor="DENIED" operation="open" class="file" profile="snap.rt-tests.cyclicdeadline" name="/proc/19557/mounts" pid=19557 comm="cyclicdeadline" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
File: /proc/19557/mounts (read)
Suggestions:
* adjust program to not access '@{PROC}/@{pid}/mounts'
* add one of 'mount-control, mount-observe, network-control, steam-support' to 'plugs'
```

After connecting `mount-observe`, we have the denials complaining about access to `/sys/kernel/debug/tracing/trace_marker`, which is solved using the `system-trace` interface.

```log
= AppArmor =
Time: Jun 24 08:51:07
Log: apparmor="DENIED" operation="open" class="file" profile="snap.rt-tests.cyclicdeadline" name="/sys/kernel/debug/tracing/trace_marker" pid=25153 comm="cyclicdeadline" requested_mask="w" denied_mask="w" fsuid=0 ouid=0
File: /sys/kernel/debug/tracing/trace_marker (write)
Suggestions:
* adjust program to not access '/sys/kernel/debug/tracing/trace_marker'
* add 'system-trace' to 'plugs'
```

After connecting `mount-observe` and `system-trace` to the rt-tests snap, the `cyclicdeadline` application works without any denials from AppArmor or Seccomp. 
