### PR TITLE
fix: hwlatdetect missing permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,9 @@ jobs:
       - name: Connectins snap interface
         run: |
           sudo snap connect rt-tests:process-control :process-control
+          sudo snap connect rt-tests:mount-observe :mount-observe
+          sudo snap connect rt-tests:system-trace :system-trace
+          sudo snap connect rt-tests:cpu-latency-dev rt-tests:dma-latency-dev
 
       - name: Creating snap aliases
         working-directory: test

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ sudo snap install rt-tests
 
 ## Configure
 
-It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface) interface to work properly:
-
+It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface), [mount-observe](https://snapcraft.io/docs/mount-observe-interface), [system-trace](https://snapcraft.io/docs/system-trace-interface) and connect the `custom-cpu-latency` plug into the `custom-cpu-latency-dev` slot to work properly:
 ```bash
 sudo snap connect rt-tests:process-control :process-control
+sudo snap connect rt-tests:mount-observe :mount-observe
+sudo snap connect rt-tests:system-trace :system-trace
+sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
 ```
 
 ## Use

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,9 +24,19 @@ platforms:
     build-on: [arm64]
     build-for: [arm64]
 
+slots:
+  custom-cpu-latency-dev:
+    interface: custom-device
+    custom-device: cpu-dma-latency
+    devices:
+      - /dev/cpu_dma_latency
+
 plugs:
   process-control:
     interface: process-control
+  custom-cpu-latency:
+    interface: custom-device
+    custom-device: cpu-dma-latency
 
 parts:
   rt-tests:
@@ -88,6 +98,7 @@ apps:
 
   hwlatdetect:
     command: usr/sbin/hwlatdetect
+    plugs: [ mount-observe, system-trace, custom-cpu-latency ]
   
   get-cyclictest-snapshot:
     command: usr/sbin/get_cyclictest_snapshot

--- a/test/rt-hwlatdetect
+++ b/test/rt-hwlatdetect
@@ -2,9 +2,6 @@
 
 . common
 
-# Being skipped because https://github.com/canonical/rt-tests-snap/issues/11
-skip_test
-
 test_init $(basename "$0")
 
 catch hwlatdetect --duration 5s


### PR DESCRIPTION
## Summary

- fixes #11
- add: mount-observe interface
- add: system-trace interface
- add: custom slot to provide access to `/dev/cpu_dma_latency`
- test: enable tests for hwlatdetect

TODO: Ask for approval on store to use [custom device](https://snapcraft.io/docs/custom-device-interface) interface

### Justification for `cpu_dma_latency`

Without the access to `/dev/cpu_dma_latency`, the `hwlatdetect` program fails with the error:

```bash
$ sudo hwlatdetect --duration 5s
hwlatdetect:  test duration 5 seconds
   detector: tracer
   parameters:
        CPU list:          None
        Latency threshold: 10us
        Sample window:      1000000us
        Sample width:      500000us
     Non-sampling period:  500000us
        Output File:       None

Starting test
Traceback (most recent call last):
  File "/snap/rt-tests/x1/usr/sbin/hwlatdetect", line 509, in <module>
    detect.detect()
  File "/snap/rt-tests/x1/usr/sbin/hwlatdetect", line 297, in detect
    self.start()
  File "/snap/rt-tests/x1/usr/sbin/hwlatdetect", line 194, in start
    self.c_states_off()
  File "/snap/rt-tests/x1/usr/sbin/hwlatdetect", line 160, in c_states_off
    self.dma_latency_handle = os.open("/dev/cpu_dma_latency", os.O_WRONLY)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 1] Operation not permitted: '/dev/cpu_dma_latency
```

