### PR TITLE
fix(tests): fix function to check output in tests

### DIFF
--- a/test/common
+++ b/test/common
@@ -66,8 +66,7 @@ partial_success(){
 }
 
 app_exit_check(){
-	[$1 -ne 0] && nonzero_fail
-	partial_success
+	[ $1 -ne 0 ] && nonzero_fail || partial_success
 }
 
 test_success() {


### PR DESCRIPTION
## Summary
- As noticed in the [last action running](https://github.com/canonical/rt-tests-snap/actions/runs/9667500593/job/26669570674#step:7:10), the function `app_exit_check` isn't working properly due to the lack of spaces between the brackets. 

- Update `app_exit_check()` function on common.