### PR TITLE
fix(ssdd): fix ssdd confinement problems

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,7 @@ jobs:
       - name: Connectins snap interface
         run: |
           sudo snap connect rt-tests:process-control :process-control
+          sudo snap connect rt-tests:docker-support
 
       - name: Creating snap aliases
         working-directory: test

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ sudo snap install rt-tests
 
 ## Configure
 
-It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface) interface to work properly:
 
+It is necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface) and [docker-support](https://snapcraft.io/docs/docker-support-interface) interfaces. The docker-support interface provides access to the [ptrace syscall](https://man7.org/linux/man-pages/man2/ptrace.2.html) needed by `ssdd`:
 ```bash
-sudo snap connect rt-tests:process-control :process-control
+sudo snap connect rt-tests:process-control
+sudo snap connect rt-tests:docker-support
 ```
 
 ## Use

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,6 +82,7 @@ apps:
   
   ssdd:
     command: usr/bin/ssdd
+    plugs: [ docker-support ]
   
   svsematest:
     command: usr/bin/svsematest

--- a/test/rt-ssdd
+++ b/test/rt-ssdd
@@ -2,19 +2,16 @@
 
 . common
 
-# Skipping because of https://github.com/canonical/rt-tests-snap/issues/12
-skip_test
-
 test_init $(basename "$0")
 
-catch ssdd --iters=10 --quiet 
+catch ssdd --iters=10 --quiet
 
 app_exit_check $?
 
 # Check program output behavior
 app_regex=(
-	'All tests PASSED.' 
-	)
+	'All tests PASSED.'
+)
 
 check_output || test_failed
 


### PR DESCRIPTION
## Summary

- Use [docker-support](https://snapcraft.io/docs/docker-support-interface) interface that provided `ptrace` syscall;
- Update README.md instructions;
- Update CI steps to connect [docker-support](https://snapcraft.io/docs/docker-support-interface) interface;
- Enable to run tests for ssdd.
