### PR TITLE
refact(doc/ci): Remove redundancy on interface connection commands

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Connectins snap interface
         run: |
-          sudo snap connect rt-tests:process-control :process-control
-          sudo snap connect rt-tests:mount-observe :mount-observe
-          sudo snap connect rt-tests:system-trace :system-trace
+          sudo snap connect rt-tests:process-control
+          sudo snap connect rt-tests:mount-observe
+          sudo snap connect rt-tests:system-trace
 
       - name: Creating snap aliases
         working-directory: test

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ sudo snap install rt-tests
 It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface), [mount-observe](https://snapcraft.io/docs/mount-observe-interface) and [system-trace](https://snapcraft.io/docs/system-trace-interface) interfaces to work properly:
 
 ```bash
-sudo snap connect rt-tests:process-control :process-control
-sudo snap connect rt-tests:mount-observe :mount-observe
-sudo snap connect rt-tests:system-trace :system-trace
+sudo snap connect rt-tests:process-control
+sudo snap connect rt-tests:mount-observe
+sudo snap connect rt-tests:system-trace
 ```
 
 ## Use


### PR DESCRIPTION
## Summary

- Remove redundancy on interface connection command
- ci(build.yaml): simplify interface connection command
- doc(README.md): Simplify interface connection command on doc
