### PR TITLE
chore: ignore squashfs-root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ stage/
 
 # Snapcraft snap files
 *.snap
+
+# Unsquashed snap filesystem
+squashfs-root/


### PR DESCRIPTION
## Summary

Ignore default unsquashed snap directory
