### PR TITLE
refact: change plug name to match naming convention

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
           sudo snap connect rt-tests:process-control
           sudo snap connect rt-tests:mount-observe
           sudo snap connect rt-tests:system-trace
-          sudo snap connect rt-tests:scheduler-debugfs
+          sudo snap connect rt-tests:sys-kernel-debug-sched-features
           sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
 
 

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ It's necessary to connect:
 - [process-control](https://snapcraft.io/docs/process-control-interface) interface;
 - [mount-observe](https://snapcraft.io/docs/mount-observe-interface) interface;
 - [system-trace](https://snapcraft.io/docs/system-trace-interface) interface;
-- `scheduler-debugfs` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
+- `sys-kernel-debug-sched-features` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
 - The `custom-cpu-latency` plug into the `custom-cpu-latency-dev` slot using the [custom-device](https://snapcraft.io/docs/custom-device-interface).
 
 ```bash
 sudo snap connect rt-tests:process-control
 sudo snap connect rt-tests:mount-observe
 sudo snap connect rt-tests:system-trace
-sudo snap connect rt-tests:scheduler-debugfs
+sudo snap connect rt-tests:sys-kernel-debug-sched-features
 sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
 ```
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,7 +32,7 @@ slots:
       - /dev/cpu_dma_latency
 
 plugs:
-  scheduler-debugfs:
+  sys-kernel-debug-sched-features:
     interface: system-files
     write:
       - /sys/kernel/debug/sched/features
@@ -63,7 +63,7 @@ apps:
 
   deadline-test:
     command: usr/bin/deadline_test
-    plugs: [ mount-observe, system-trace, scheduler-debugfs ]
+    plugs: [ mount-observe, system-trace, sys-kernel-debug-sched-features ]
   
   hackbench:
     command: usr/bin/hackbench


### PR DESCRIPTION
## Summary

Plug name changed to be consistent with the current naming convention used in system-files interface.

As suggested [in the forum post](https://forum.snapcraft.io/t/system-files-request-for-rt-tests-snap/40790).