### PR TITLE
refact: replace custom-cpu-latency with cpu-control interface

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
           sudo snap connect rt-tests:mount-observe
           sudo snap connect rt-tests:system-trace
           sudo snap connect rt-tests:sys-kernel-debug-sched-features
-          sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
+          sudo snap connect rt-tests:cpu-control
 
 
       - name: Creating snap aliases

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ sudo snap connect rt-tests:system-trace
 sudo snap connect rt-tests:sys-kernel-debug-sched-features
 sudo snap connect rt-tests:cpu-control
 ```
+> **_NOTE:_** The `cpu-control` interface gets auto-connected when installed from the store.
 
 ## Use
 The program commands are available within the snap's namespace.

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ It's necessary to connect:
 - [process-control](https://snapcraft.io/docs/process-control-interface) interface;
 - [mount-observe](https://snapcraft.io/docs/mount-observe-interface) interface;
 - [system-trace](https://snapcraft.io/docs/system-trace-interface) interface;
+- [cpu-control](https://snapcraft.io/docs/cpu-control-interface) interface;
 - `sys-kernel-debug-sched-features` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
-- The `custom-cpu-latency` plug into the `custom-cpu-latency-dev` slot using the [custom-device](https://snapcraft.io/docs/custom-device-interface).
 
 ```bash
 sudo snap connect rt-tests:process-control
 sudo snap connect rt-tests:mount-observe
 sudo snap connect rt-tests:system-trace
 sudo snap connect rt-tests:sys-kernel-debug-sched-features
-sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
+sudo snap connect rt-tests:cpu-control
 ```
 
 ## Use

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,13 +24,6 @@ platforms:
     build-on: [arm64]
     build-for: [arm64]
 
-slots:
-  custom-cpu-latency-dev:
-    interface: custom-device
-    custom-device: cpu-dma-latency
-    devices:
-      - /dev/cpu_dma_latency
-
 plugs:
   sys-kernel-debug-sched-features:
     interface: system-files
@@ -38,9 +31,6 @@ plugs:
       - /sys/kernel/debug/sched/features
   process-control:
     interface: process-control
-  custom-cpu-latency:
-    interface: custom-device
-    custom-device: cpu-dma-latency
 
 parts:
   rt-tests:
@@ -56,7 +46,7 @@ apps:
 
   cyclicdeadline:
     command: usr/bin/cyclicdeadline
-    plugs: [ mount-observe, system-trace ]
+    plugs: [ mount-observe, system-trace, cpu-control ]
   
   cyclictest:
     command: usr/bin/cyclictest
@@ -103,7 +93,7 @@ apps:
 
   hwlatdetect:
     command: usr/sbin/hwlatdetect
-    plugs: [ mount-observe, system-trace, custom-cpu-latency ]
+    plugs: [ mount-observe, system-trace, cpu-control ]
   
   get-cyclictest-snapshot:
     command: usr/sbin/get_cyclictest_snapshot


### PR DESCRIPTION
## Summary
As `cpu-control` is going to have the capability to control `/dev/cpu_dma_latency`, there is no need for a custom-device interface here.

Refer to: https://github.com/snapcore/snapd/pull/14154