### PR TITLE
Fix few confinement issues for `deadline-test` and `hwlatdetect`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
           sudo snap connect rt-tests:process-control
           sudo snap connect rt-tests:mount-observe
           sudo snap connect rt-tests:system-trace
-          sudo snap connect rt-tests:scheduler-debugfs
+          sudo snap connect rt-tests:sys-kernel-debug-sched-features
           sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
 
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
           sudo snap connect rt-tests:mount-observe
           sudo snap connect rt-tests:system-trace
           sudo snap connect rt-tests:sys-kernel-debug-sched-features
-          sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
+          sudo snap connect rt-tests:cpu-control
 
 
       - name: Creating snap aliases

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,9 @@ jobs:
       - name: Connectins snap interface
         run: |
           sudo snap connect rt-tests:process-control :process-control
+          sudo snap connect rt-tests:mount-observe :mount-observe
+          sudo snap connect rt-tests:system-trace :system-trace
+          sudo snap connect rt-tests:cpu-latency-dev rt-tests:dma-latency-dev
 
       - name: Creating snap aliases
         working-directory: test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, fix-confinement ]
   # Allow manual trigger
   workflow_dispatch:
 
@@ -49,10 +49,12 @@ jobs:
 
       - name: Connectins snap interface
         run: |
-          sudo snap connect rt-tests:process-control :process-control
-          sudo snap connect rt-tests:mount-observe :mount-observe
-          sudo snap connect rt-tests:system-trace :system-trace
-          sudo snap connect rt-tests:cpu-latency-dev rt-tests:dma-latency-dev
+          sudo snap connect rt-tests:process-control
+          sudo snap connect rt-tests:mount-observe
+          sudo snap connect rt-tests:system-trace
+          sudo snap connect rt-tests:scheduler-debugfs
+          sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
+
 
       - name: Creating snap aliases
         working-directory: test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,6 @@ jobs:
           sudo snap connect rt-tests:mount-observe
           sudo snap connect rt-tests:system-trace
           sudo snap connect rt-tests:sys-kernel-debug-sched-features
-          sudo snap connect rt-tests:cpu-control
 
       - name: Creating snap aliases
         working-directory: test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, fix-confinement ]
+    branches: [ main ]
   # Allow manual trigger
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,17 @@ It's necessary to connect:
 - [process-control](https://snapcraft.io/docs/process-control-interface) interface;
 - [mount-observe](https://snapcraft.io/docs/mount-observe-interface) interface;
 - [system-trace](https://snapcraft.io/docs/system-trace-interface) interface;
+- [cpu-control](https://snapcraft.io/docs/cpu-control-interface) interface;
 - `sys-kernel-debug-sched-features` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
-- The `custom-cpu-latency` plug into the `custom-cpu-latency-dev` slot using the [custom-device](https://snapcraft.io/docs/custom-device-interface).
 
 ```bash
 sudo snap connect rt-tests:process-control
 sudo snap connect rt-tests:mount-observe
 sudo snap connect rt-tests:system-trace
 sudo snap connect rt-tests:sys-kernel-debug-sched-features
-sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
+sudo snap connect rt-tests:cpu-control
 ```
+> **_NOTE:_** The `cpu-control` interface gets auto-connected when installed from the store.
 
 ## Use
 The program commands are available within the snap's namespace.

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ It's necessary to connect:
 - [process-control](https://snapcraft.io/docs/process-control-interface) interface;
 - [mount-observe](https://snapcraft.io/docs/mount-observe-interface) interface;
 - [system-trace](https://snapcraft.io/docs/system-trace-interface) interface;
-- `scheduler-debugfs` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
+- `sys-kernel-debug-sched-features` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
 - The `custom-cpu-latency` plug into the `custom-cpu-latency-dev` slot using the [custom-device](https://snapcraft.io/docs/custom-device-interface).
 
 ```bash
 sudo snap connect rt-tests:process-control
 sudo snap connect rt-tests:mount-observe
 sudo snap connect rt-tests:system-trace
-sudo snap connect rt-tests:scheduler-debugfs
+sudo snap connect rt-tests:sys-kernel-debug-sched-features
 sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,18 @@ sudo snap install rt-tests
 
 ## Configure
 
-It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface), [mount-observe](https://snapcraft.io/docs/mount-observe-interface), [system-trace](https://snapcraft.io/docs/system-trace-interface) and connect the `custom-cpu-latency` plug into the `custom-cpu-latency-dev` slot to work properly:
+It's necessary to connect:
+- [process-control](https://snapcraft.io/docs/process-control-interface) interface;
+- [mount-observe](https://snapcraft.io/docs/mount-observe-interface) interface;
+- [system-trace](https://snapcraft.io/docs/system-trace-interface) interface;
+- `scheduler-debugfs` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
+- The `custom-cpu-latency` plug into the `custom-cpu-latency-dev` slot using the [custom-device](https://snapcraft.io/docs/custom-device-interface).
+
 ```bash
-sudo snap connect rt-tests:process-control :process-control
-sudo snap connect rt-tests:mount-observe :mount-observe
-sudo snap connect rt-tests:system-trace :system-trace
+sudo snap connect rt-tests:process-control
+sudo snap connect rt-tests:mount-observe
+sudo snap connect rt-tests:system-trace
+sudo snap connect rt-tests:scheduler-debugfs
 sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ sudo snap install rt-tests
 
 ## Configure
 
-It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface) interface to work properly:
-
+It's necessary to connect the [process-control](https://snapcraft.io/docs/process-control-interface), [mount-observe](https://snapcraft.io/docs/mount-observe-interface), [system-trace](https://snapcraft.io/docs/system-trace-interface) and connect the `custom-cpu-latency` plug into the `custom-cpu-latency-dev` slot to work properly:
 ```bash
 sudo snap connect rt-tests:process-control :process-control
+sudo snap connect rt-tests:mount-observe :mount-observe
+sudo snap connect rt-tests:system-trace :system-trace
+sudo snap connect rt-tests:custom-cpu-latency rt-tests:custom-cpu-latency-dev
 ```
 
 ## Use

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ It's necessary to connect:
 - [process-control](https://snapcraft.io/docs/process-control-interface) interface;
 - [mount-observe](https://snapcraft.io/docs/mount-observe-interface) interface;
 - [system-trace](https://snapcraft.io/docs/system-trace-interface) interface;
-- [cpu-control](https://snapcraft.io/docs/cpu-control-interface) interface;
 - `sys-kernel-debug-sched-features` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
 
 
@@ -52,9 +51,8 @@ sudo snap connect rt-tests:process-control
 sudo snap connect rt-tests:mount-observe
 sudo snap connect rt-tests:system-trace
 sudo snap connect rt-tests:sys-kernel-debug-sched-features
-sudo snap connect rt-tests:cpu-control
 ```
-> **_NOTE:_** The `cpu-control` interface gets auto-connected when installed from the store.
+> **_NOTE:_** The `sys-kernel-debug-sched-features` interface gets auto-connected when installed from the store.
 
 ## Use
 The program commands are available within the snap's namespace.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,9 +24,19 @@ platforms:
     build-on: [arm64]
     build-for: [arm64]
 
+slots:
+  custom-cpu-latency-dev:
+    interface: custom-device
+    custom-device: cpu-dma-latency
+    devices:
+      - /dev/cpu_dma_latency
+
 plugs:
   process-control:
     interface: process-control
+  custom-cpu-latency:
+    interface: custom-device
+    custom-device: cpu-dma-latency
 
 parts:
   rt-tests:
@@ -88,6 +98,7 @@ apps:
 
   hwlatdetect:
     command: usr/sbin/hwlatdetect
+    plugs: [ mount-observe, system-trace, custom-cpu-latency ]
   
   get-cyclictest-snapshot:
     command: usr/sbin/get_cyclictest_snapshot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,13 +24,6 @@ platforms:
     build-on: [arm64]
     build-for: [arm64]
 
-slots:
-  custom-cpu-latency-dev:
-    interface: custom-device
-    custom-device: cpu-dma-latency
-    devices:
-      - /dev/cpu_dma_latency
-
 plugs:
   sys-kernel-debug-sched-features:
     interface: system-files
@@ -38,9 +31,6 @@ plugs:
       - /sys/kernel/debug/sched/features
   process-control:
     interface: process-control
-  custom-cpu-latency:
-    interface: custom-device
-    custom-device: cpu-dma-latency
 
 parts:
   rt-tests:
@@ -56,7 +46,7 @@ apps:
 
   cyclicdeadline:
     command: usr/bin/cyclicdeadline
-    plugs: [ mount-observe, system-trace ]
+    plugs: [ mount-observe, system-trace, cpu-control ]
   
   cyclictest:
     command: usr/bin/cyclictest
@@ -103,7 +93,7 @@ apps:
 
   hwlatdetect:
     command: usr/sbin/hwlatdetect
-    plugs: [ mount-observe, system-trace, custom-cpu-latency ]
+    plugs: [ mount-observe, system-trace, cpu-control ]
   
   get-cyclictest-snapshot:
     command: usr/sbin/get_cyclictest_snapshot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,7 @@ apps:
 
   cyclicdeadline:
     command: usr/bin/cyclicdeadline
-    plugs: [ mount-observe, system-trace, cpu-control ]
+    plugs: [ mount-observe, system-trace ]
   
   cyclictest:
     command: usr/bin/cyclictest
@@ -93,7 +93,7 @@ apps:
 
   hwlatdetect:
     command: usr/sbin/hwlatdetect
-    plugs: [ mount-observe, system-trace, cpu-control ]
+    plugs: [ mount-observe, system-trace ]
   
   get-cyclictest-snapshot:
     command: usr/sbin/get_cyclictest_snapshot

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,7 +32,7 @@ slots:
       - /dev/cpu_dma_latency
 
 plugs:
-  scheduler-debugfs:
+  sys-kernel-debug-sched-features:
     interface: system-files
     write:
       - /sys/kernel/debug/sched/features
@@ -63,7 +63,7 @@ apps:
 
   deadline-test:
     command: usr/bin/deadline_test
-    plugs: [ mount-observe, system-trace, scheduler-debugfs ]
+    plugs: [ mount-observe, system-trace, sys-kernel-debug-sched-features ]
   
   hackbench:
     command: usr/bin/hackbench

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,10 @@ slots:
       - /dev/cpu_dma_latency
 
 plugs:
+  scheduler-debugfs:
+    interface: system-files
+    write:
+      - /sys/kernel/debug/sched/features
   process-control:
     interface: process-control
   custom-cpu-latency:
@@ -46,19 +50,20 @@ parts:
     override-build: |
       craftctl set version=$(oslat --version | cut -d ' ' -f 3)
     stage-packages:
-      - libnuma1
       - rt-tests
 
 apps:
 
   cyclicdeadline:
     command: usr/bin/cyclicdeadline
+    plugs: [ mount-observe, system-trace ]
   
   cyclictest:
     command: usr/bin/cyclictest
 
   deadline-test:
     command: usr/bin/deadline_test
+    plugs: [ mount-observe, system-trace, scheduler-debugfs ]
   
   hackbench:
     command: usr/bin/hackbench

--- a/test/rt-deadline_test
+++ b/test/rt-deadline_test
@@ -2,9 +2,6 @@
 
 . common
 
-# Skipping this because of: https://github.com/canonical/rt-tests-snap/issues/8
-skip_test
-
 test_init $(basename "$0")
 
 catch deadline_test -t $(nproc) -s 3500 -i 50
@@ -18,7 +15,6 @@ app_regex=(
 	'New calculated loops for \d+us=\d+' \
 	'Diff from last calculation: -?\d+ loops'
 	'deadline thread \d+' \
-	'thread\[\d+\] runtime=\d+us deadline=\d+ loops=\d+' \
 	'missed deadlines\s*=\s*\d+' \
 	'missed periods\s*=\s*\d+' \
 	'Total adjustments\s*=\s*\d+\s*us' \

--- a/test/rt-hwlatdetect
+++ b/test/rt-hwlatdetect
@@ -2,9 +2,6 @@
 
 . common
 
-# Being skipped because https://github.com/canonical/rt-tests-snap/issues/11
-skip_test
-
 test_init $(basename "$0")
 
 catch hwlatdetect --duration 5s

--- a/test/rt-hwlatdetect
+++ b/test/rt-hwlatdetect
@@ -2,6 +2,9 @@
 
 . common
 
+# Being skipped because https://github.com/canonical/rt-tests-snap/issues/11
+skip_test
+
 test_init $(basename "$0")
 
 catch hwlatdetect --duration 5s


### PR DESCRIPTION
## Summary
Add system-files interface to access `/sys/kernel/debug/sched/features` from `deadline-test`

Add mount-observe, system-trace to `deadline-test` and `hwlatdetect`

## Related issues
- Split from #26, without the cpu-control addition. This is not yet effective, as the changes required haven't landed in a stable release of SnapD. 
- Closes #8 
- Closes #11
