### PR TITLE
Add related issues section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 ## Summary
 PR description, link to related documents and PRs
 
-## Related Issues
+## Related issues
 <!-- Add issues in bullet form to show issue titles. Use Github keywords to link+close issues -->
 
-## Testing Steps
+## Testing steps
 <!-- Steps to test the changes. Remove if not relevant -->
 
 <!-- Reminders:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,17 @@
 ## Summary
-PR description, link to related documents and PRs
+<!-- PR description, link to related documents and PRs -->
 
 ## Related issues
-<!-- Add issues in bullet form to show issue titles. Use Github keywords to link+close issues -->
+<!-- Add issues in bullets. Use Github keywords to link the PR to issues -->
 
 ## Testing steps
-<!-- Steps to test the changes. Remove if not relevant -->
+<!-- Steps to test the changes -->
 
 <!-- Reminders:
- - Incremented the snap version
- - Added or updated tests
- - Updated the CI/CD pipelines
- - Updated the README(s)
- - Updated external documentation
+ - Remove empty sections
+ - Increment the version
+ - Add/update tests
+ - Update CI/CD pipelines
+ - Update README(s)
+ - Update external docs
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,8 @@
 ## Summary
-PR description, link to relevant issues and PRs
+PR description, link to related documents and PRs
+
+## Related Issues
+<!-- Add issues in bullet form to show issue titles. Use Github keywords to link+close issues -->
 
 ## Testing Steps
 <!-- Steps to test the changes. Remove if not relevant -->


### PR DESCRIPTION
Updating the PR template to split issues and summary. See this in action in `https://github.com/canonical/rt-tests-snap/pull/31`