### PR TITLE
Add cpu-control interface to allow control of CPU C-state

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,7 @@ jobs:
           sudo snap connect rt-tests:mount-observe
           sudo snap connect rt-tests:system-trace
           sudo snap connect rt-tests:sys-kernel-debug-sched-features
+          sudo snap connect rt-tests:cpu-control
 
       - name: Creating snap aliases
         working-directory: test

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ It's necessary to connect:
 - [mount-observe](https://snapcraft.io/docs/mount-observe-interface) interface;
 - [system-trace](https://snapcraft.io/docs/system-trace-interface) interface;
 - `sys-kernel-debug-sched-features` plug into the [system-files](https://snapcraft.io/docs/system-files-interface) interface;
+- [cpu-control](https://snapcraft.io/docs/cpu-control-interface) interface
 
 
 ```bash
@@ -51,6 +52,7 @@ sudo snap connect rt-tests:process-control
 sudo snap connect rt-tests:mount-observe
 sudo snap connect rt-tests:system-trace
 sudo snap connect rt-tests:sys-kernel-debug-sched-features
+sudo snap connect rt-tests:cpu-control
 ```
 > **_NOTE:_** The `sys-kernel-debug-sched-features` interface gets auto-connected when installed from the store.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,7 @@ apps:
 
   cyclicdeadline:
     command: usr/bin/cyclicdeadline
-    plugs: [ mount-observe, system-trace ]
+    plugs: [ mount-observe, system-trace, cpu-control ]
   
   cyclictest:
     command: usr/bin/cyclictest
@@ -93,7 +93,7 @@ apps:
 
   hwlatdetect:
     command: usr/sbin/hwlatdetect
-    plugs: [ mount-observe, system-trace ]
+    plugs: [ mount-observe, system-trace, cpu-control ]
   
   get-cyclictest-snapshot:
     command: usr/sbin/get_cyclictest_snapshot

--- a/test/rt-hwlatdetect
+++ b/test/rt-hwlatdetect
@@ -2,9 +2,6 @@
 
 . common
 
-# Being skipped because https://github.com/canonical/rt-tests-snap/issues/11
-skip_test
-
 test_init $(basename "$0")
 
 catch hwlatdetect --duration 5s


### PR DESCRIPTION
## Summary
Access is via the `/dev/cpu_dma_latency` device node

## Related Issues
- Closes #21
- Pending stable release of cpu-control interface changes: https://github.com/snapcore/snapd/pull/14154

<!-- Reminders:
 - Incremented the snap version
 - Added or updated tests
 - Updated the CI/CD pipelines
 - Updated the README(s)
 - Updated external documentation
-->
