### PR TITLE
docs: add devmode installation note for ssdd in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The programs include:
 - [rt-migrate-test](https://manpages.ubuntu.com/manpages/noble/en/man8/rt-migrate-test.8.html)
 - [signaltest](https://manpages.ubuntu.com/manpages/noble/en/man8/signaltest.8.html)
 - [sigwaittest](https://manpages.ubuntu.com/manpages/noble/en/man8/sigwaittest.8.html)
-- [ssdd](https://manpages.ubuntu.com/manpages/noble/en/man8/ssdd.8.html) 
+- [ssdd](https://manpages.ubuntu.com/manpages/noble/en/man8/ssdd.8.html) rt-tests needs to be installed in [devmode](https://snapcraft.io/docs/install-modes#heading--devmode)
 - [svsematest](https://manpages.ubuntu.com/manpages/noble/en/man8/svsematest.8.html)
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The programs include:
 - [rt-migrate-test](https://manpages.ubuntu.com/manpages/noble/en/man8/rt-migrate-test.8.html)
 - [signaltest](https://manpages.ubuntu.com/manpages/noble/en/man8/signaltest.8.html)
 - [sigwaittest](https://manpages.ubuntu.com/manpages/noble/en/man8/sigwaittest.8.html)
-- [ssdd](https://manpages.ubuntu.com/manpages/noble/en/man8/ssdd.8.html) - rt-tests needs to be installed in [devmode](https://snapcraft.io/docs/install-modes#heading--devmode)
+- [ssdd](https://manpages.ubuntu.com/manpages/noble/en/man8/ssdd.8.html) - Works only when the snap is installed in [devmode](https://snapcraft.io/docs/install-modes#heading--devmode); see #12
 - [svsematest](https://manpages.ubuntu.com/manpages/noble/en/man8/svsematest.8.html)
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The programs include:
 - [rt-migrate-test](https://manpages.ubuntu.com/manpages/noble/en/man8/rt-migrate-test.8.html)
 - [signaltest](https://manpages.ubuntu.com/manpages/noble/en/man8/signaltest.8.html)
 - [sigwaittest](https://manpages.ubuntu.com/manpages/noble/en/man8/sigwaittest.8.html)
-- [ssdd](https://manpages.ubuntu.com/manpages/noble/en/man8/ssdd.8.html) rt-tests needs to be installed in [devmode](https://snapcraft.io/docs/install-modes#heading--devmode)
+- [ssdd](https://manpages.ubuntu.com/manpages/noble/en/man8/ssdd.8.html) - rt-tests needs to be installed in [devmode](https://snapcraft.io/docs/install-modes#heading--devmode)
 - [svsematest](https://manpages.ubuntu.com/manpages/noble/en/man8/svsematest.8.html)
 
 ## Known Issues


### PR DESCRIPTION
## Summary
Updated the README to include a note that rt-tests need to be installed in **devmode** for `ssdd` usage.

## Related issues
- #12
