### PR TITLE
fix: wrong slot name

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,7 +81,7 @@ apps:
 
   pmqtest:
     command: usr/bin/pmqtest
-    slots: [ posix-mq ]
+    slots: [ rt-tests-posix-mq ]
     plugs: [ process-control ]
 
   ptsematest:


### PR DESCRIPTION
## Summary
During installation, `snapd` identifies `posix-mq` as a slot and looks for a slot declaration named `posix-mq`. However, the actual slot is named `rt-tests-posix-mq`. Since slots can share the same name as their interfaces, `snapd` correctly identifies the interface to be used but fails to find a slot with the same name as the interface. As a result, it also doesn't find the associated `path` attribute, which triggers the warning message.

- Fixes wrong slot name

## Related issues

- Fixes #38

## Testing steps

```bash

# Install the recently upload snap to the branch pr-posixmq-fix
sudo snap install rt-tests --channel latest/edge/pr-posixmq-fix

# See that there are no warnings related to the rt-tests snap
snap warnings
```
