### PR TITLE
add: '-dirty' suffix to point uncommitted changes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,7 +47,7 @@ parts:
       - rt-tests
       - git
     override-build: |
-      craftctl set version=$(oslat --version | cut -d ' ' -f 3)+$(git rev-parse --short HEAD)
+      craftctl set version=$(oslat --version | cut -d ' ' -f 3)+$(git describe --always --dirty)
     stage-packages:
       - rt-tests
 


### PR DESCRIPTION
## Summary

While experimenting and building without committing changes, the `-dirty` prefix will be added to indicate that the `.snap` build includes uncommitted modifications.

If the Git working tree is clean, the hash remains the same size as it would for a committed build.

## Related issues
<!-- Add issues in bullets. Use Github keywords to link the PR to issues -->
- complements the work done on https://github.com/canonical/rt-tests-snap/pull/40

## Testing steps

```console
# Modify something on the snap
$ sed -i '1i # demonstration' snap/snapcraft.yaml

# Build the snap and Check the name now has `<git-hash>-dirty` 
$ snapcraft
Packed rt-tests_2.50+4bf666c-dirty_amd64.snap

```
