### PR TITLE
Fix: wrong version of rt-tests

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
       - rt-tests
       - git
     override-build: |
-      craftctl set version=$(oslat --version | cut -d ' ' -f 3)+$(git describe --always --dirty)
+      craftctl set version=$(dpkg-query -W -f='${Version}\n' rt-tests)+$(git describe --always --dirty)
     stage-packages:
       - rt-tests
 


### PR DESCRIPTION
## Summary
Uses dpkg-query to fetch version of the rt-tests deb package, as suggested here: https://github.com/canonical/rt-tests-snap/issues/54#issuecomment-4260293903


## Related issues
- Closes: https://github.com/canonical/rt-tests-snap/issues/54

## Testing steps

- Fetch this branch locally: 
```shell
git fetch git@github.com:canonical/rt-tests-snap.git pull/56/head:pr_fixed_version
git switch pr_fixed_version
```

- switch to the branch and build:
```shell
snapcraft pack -v
```
- After the build, check the version (appended to the `.snap` filename):

<!-- Reminders:
 - Remove empty sections
 - Increment the version
 - Add/update tests
 - Update CI/CD pipelines
 - Update README(s)
 - Update external docs
-->
