### PR TITLE
ci: Force Snapd installation on build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,15 +43,12 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y snapd
           sudo snap install snapd
+          sudo snap refresh snapd
 
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.SNAP_AMD64 }}
-
-      - name: refresh snapd
-        run: |
-          sudo snap refresh snapd
 
       - name: Install snap
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,12 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Prepare Snapd
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y snapd
+          sudo snap install snapd
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,4 +71,4 @@ jobs:
         working-directory: test
         run: |
           sudo ./run
- 
+


### PR DESCRIPTION
## Summary

GitHub Actions doesn't run with a vanilla Ubuntu image, and because of that, snapd might not be installed or might not be installed as a snap. This forces snapd to be present.

## Related issues

- Closes: https://github.com/canonical/rt-tests-snap/issues/57