### PR TITLE
Fix snapcraft lint warnings

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,5 @@
 name: rt-tests
+title: RT-Tests
 base: core24
 version: nil
 summary: Real-time test suite
@@ -9,12 +10,18 @@ description: |
   cyclicdeadline, cyclictest, deadline_test, hackbench, hwlatdetect, oslat, pi_stress, pip_stress, pmqtest,
   ptsematest, queuelat, rt-migrate-test, signaltest, sigwaittest, ssdd, svsematest.
 
-  For usage instructions, refer to:  https://github.com/canonical/rt-tests-snap
-
 license: GPL-2.0-or-later AND LGPL-2.1-or-later
 grade: stable
 confinement: strict
 adopt-info: rt-tests
+contact:
+  - kevin.becker@canonical.com
+  - benjamin.wheeler@canonical.com
+
+website: https://github.com/canonical/rt-tests-snap
+source-code: https://github.com/canonical/rt-tests-snap
+issues: https://github.com/canonical/rt-tests-snap/issues
+
 
 platforms:
   amd64:


### PR DESCRIPTION
The only lint warning that shows up now is for the "donation" entry, but I don't have a good idea of what to put there.

## Summary
Fix lint errors printed during `snapcraft pack`.

Before:
```
> snapcraft pack
Lint warnings:
- metadata: Metadata field 'title' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#title)
- metadata: Metadata field 'contact' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#contact)
Lint information:
- metadata: Metadata field 'donation' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#donation)
- metadata: Metadata field 'issues' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#issues)
- metadata: Metadata field 'source-code' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#source-code)
- metadata: Metadata field 'website' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#website)
Packed rt-tests_2.5-1+71ee57d_amd64.snap
```

After:
```
> snapcraft pack
Lint information:
- metadata: Metadata field 'donation' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#donation)
Packed rt-tests_2.5-1+71ee57d-dirty_amd64.snap
```