### PR TITLE
update to core26

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,8 @@ jobs:
       - name: Build snap
         uses: snapcore/action-build@v1
         id: snapcraft
+        with:
+          snapcraft-channel: candidate  # until snapcrarft 9 is released, then we can switch to stable
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: rt-tests
 title: RT-Tests
-base: core24
+base: core26
 version: nil
 summary: Real-time test suite
 description: |


### PR DESCRIPTION
v9.0 of snapcraft is necessary to build core26 snaps for stable.
At time of commit, this requires the candidate channel of snapcraft to build.

Use the candidate channel so ci builds still work.

This is a separate commit so that it can be reverted easily later on
when v9.0 hits stable.