### PR TITLE
expect_fail and catch_timeout

### DIFF
--- a/test/common
+++ b/test/common
@@ -14,6 +14,9 @@ readonly SKIP_EXIT_CODE=200
 readonly XFAIL_EXIT_CODE=201
 readonly XPASS_EXIT_CODE=202
 
+# Default wall-clock limit (seconds) for catch_timeout
+readonly DEFAULT_TIMEOUT=30
+
 printc() {
     local color="$1"
     shift
@@ -98,6 +101,25 @@ app_exit_check(){
 test_success() {
 	printc "GREEN" "PASS"
 	exit 0
+}
+
+# Like `catch`, but kills the command if it runs longer than a timeout.
+# Usage: catch_timeout [SECONDS] COMMAND [ARG1[ ARG2[ ...]]]
+# If the first argument is a positive integer it's used as the timeout,
+# otherwise DEFAULT_TIMEOUT is used. On timeout, `timeout` sends TERM and
+# then KILL, exiting with status 124, which propagates through `catch`.
+catch_timeout() {
+	local seconds=$DEFAULT_TIMEOUT
+	if [[ $1 =~ ^[0-9]+$ ]]; then
+		seconds=$1
+		shift
+	fi
+	catch timeout --kill-after=5 "$seconds" "$@"
+	local rc=$?
+	if [ $rc -eq 124 ]; then
+		printc "YELLOW" "[WARN] Command timed out after ${seconds}s and was killed"
+	fi
+	return $rc
 }
 
 # Execute the command while `Catch`ing the stdout to APP_STDOUT variable

--- a/test/common
+++ b/test/common
@@ -11,6 +11,8 @@ COLOR['NC']='\033[0m'
 COLOR['CYAN']='\033[0;96m'
 
 readonly SKIP_EXIT_CODE=200
+readonly XFAIL_EXIT_CODE=201
+readonly XPASS_EXIT_CODE=202
 
 printc() {
     local color="$1"
@@ -40,6 +42,30 @@ check_output(){
 skip_test(){
 	printc "YELLOW" "[WARN] Test being skipped"
 	exit $SKIP_EXIT_CODE
+}
+
+# pytest-style xfail: keep running the test, but don't let a failure abort
+# with an error. Call this near the top of a test script (like skip_test).
+# If the test subsequently fails, it's reported as an expected failure (XFAIL);
+# if it unexpectedly passes, it's reported as XPASS.
+expect_fail(){
+	trap '_xfail_handler $?' EXIT
+}
+
+_xfail_handler(){
+	local rc=$1
+	# Clear the trap so our own exit below doesn't re-trigger it
+	trap - EXIT
+	if [ $rc -eq 0 ]; then
+		printc "YELLOW" "[XPASS] Test passed unexpectedly"
+		exit $XPASS_EXIT_CODE
+	elif [ $rc -eq $SKIP_EXIT_CODE ]; then
+		# A skip inside an xfail test is still just a skip
+		exit $rc
+	else
+		printc "YELLOW" "[XFAIL] Test failed as expected (exit $rc)"
+		exit $XFAIL_EXIT_CODE
+	fi
 }
 
 test_init(){

--- a/test/rt-cyclicdeadline
+++ b/test/rt-cyclicdeadline
@@ -4,6 +4,8 @@
 
 test_init $(basename "$0")
 
+expect_fail
+
 catch cyclicdeadline --quiet --interval=3500 --duration=1s --threads=$(nproc)
 
 app_exit_check $?

--- a/test/rt-deadline_test
+++ b/test/rt-deadline_test
@@ -4,6 +4,8 @@
 
 test_init $(basename "$0")
 
+expect_fail
+
 catch deadline_test -t $(nproc) -s 3500 -i 50
 
 app_exit_check $?

--- a/test/rt-queuelat
+++ b/test/rt-queuelat
@@ -6,7 +6,7 @@ test_init $(basename "$0")
 
 expect_fail
 
-catch queuelat --cycles 100 --max-len 10000 --packets 1 --freq 10 
+catch_timeout 30 queuelat --cycles 100 --max-len 10000 --packets 1 --freq 10 
 
 app_exit_check $?
 

--- a/test/rt-queuelat
+++ b/test/rt-queuelat
@@ -4,6 +4,8 @@
 
 test_init $(basename "$0")
 
+expect_fail
+
 catch queuelat --cycles 100 --max-len 10000 --packets 1 --freq 10 
 
 app_exit_check $?

--- a/test/rt-ssdd
+++ b/test/rt-ssdd
@@ -7,7 +7,7 @@ skip_test
 
 test_init $(basename "$0")
 
-catch ssdd --iters=10 --quiet 
+catch_timeout 30 ssdd --iters=10 --quiet 
 
 app_exit_check $?
 

--- a/test/run
+++ b/test/run
@@ -4,11 +4,19 @@
 
 check_root
 
-passed=() failed=() skiped=()
+passed=() failed=() skiped=() xfailed=() xpassed=()
 
 check_failure(){
 	if [ $1 -eq $SKIP_EXIT_CODE ]; then
 		skiped=(${skiped[@]} $test)
+		return
+	fi
+	if [ $1 -eq $XFAIL_EXIT_CODE ]; then
+		xfailed=(${xfailed[@]} $test)
+		return
+	fi
+	if [ $1 -eq $XPASS_EXIT_CODE ]; then
+		xpassed=(${xpassed[@]} $test)
 		return
 	fi
 	failed=(${failed[@]} $test)	
@@ -26,6 +34,8 @@ done
 printc "CYAN" "SUMMARY:"
 printc "CYAN" "  SKIPPED ${#skiped[@]}  (${skiped[@]}) "
 printc "CYAN" "  PASSED  ${#passed[@]}"
+printc "CYAN" "  XFAILED ${#xfailed[@]}  (${xfailed[@]}) "
+printc "CYAN" "  XPASSED ${#xpassed[@]}  (${xpassed[@]}) "
 printc "CYAN" "  FAILED  ${#failed[@]}  (${failed[@]})"
 
 [ ${#failed} -eq 0 ]


### PR DESCRIPTION
- add `expect_fail`, which runs the test instead of skipping it. Provides more information than simply skipping.
- add `catch_timeout`, which terminates the test after a set period. Fixes queuelat hang.
  - note, this doesn't appear to work on rt-ssdd, so skip that one for now.